### PR TITLE
Increased the size of .share__input

### DIFF
--- a/_sass/blocks/_share.scss
+++ b/_sass/blocks/_share.scss
@@ -15,7 +15,8 @@
     &__input {
         padding: 0 25px;
         width: 100%;
-        max-width: 500px;
+        max-width: 550px;
+        text-align: center;
         height: 50px;
         color: #e5e5e5;
         font-size: 16px;


### PR DESCRIPTION
Increased the size of .share__input so that it can include all of the options if they're ticked.

Also align center, because.
